### PR TITLE
Release the GVL when deflating

### DIFF
--- a/ext/brotli/brotli.cc
+++ b/ext/brotli/brotli.cc
@@ -122,25 +122,25 @@ brotli_deflate_parse_options(brotli::BrotliParams& params, VALUE opts)
     }
 }
 
-struct brotli_deflate_t
+struct brotli_deflate_args_t
 {
     char *str;
     size_t str_length;
     std::string buf;
     brotli::BrotliParams *params;
 
-} brotli_deflate_t;
+} brotli_deflate_args_t;
 
 static void *
 brotli_deflate_no_gvl(void *arg)
 {
-    struct brotli_deflate_t *args = (struct brotli_deflate_t *)arg;
+    struct brotli_deflate_args_t *args = (struct brotli_deflate_args_t *)arg;
 
     brotli::BrotliMemIn in(args->str, args->str_length);
     args->buf.reserve(args->str_length * 2 + 1);
     brotli::BrotliStringOut out(&args->buf, args->buf.capacity());
 
-    return (void *)brotli::BrotliCompress(*(args->params), &in, &out);
+    return (void *)(bool)brotli::BrotliCompress(*(args->params), &in, &out);
 }
 
 static VALUE
@@ -156,7 +156,7 @@ brotli_deflate(int argc, VALUE *argv, VALUE self)
         brotli_deflate_parse_options(params, opts);
     }
 
-    struct brotli_deflate_t args = {
+    struct brotli_deflate_args_t args = {
         .str = RSTRING_PTR(str),
         .str_length = RSTRING_LEN(str),
         .params = &params

--- a/ext/brotli/brotli.cc
+++ b/ext/brotli/brotli.cc
@@ -1,4 +1,5 @@
 #include "brotli.h"
+#include "ruby/thread.h"
 
 #define CSTR2SYM(x) ID2SYM(rb_intern(x))
 
@@ -121,6 +122,27 @@ brotli_deflate_parse_options(brotli::BrotliParams& params, VALUE opts)
     }
 }
 
+struct brotli_deflate_t
+{
+    char *str;
+    size_t str_length;
+    std::string buf;
+    brotli::BrotliParams *params;
+
+} brotli_deflate_t;
+
+static void *
+brotli_deflate_no_gvl(void *arg)
+{
+    struct brotli_deflate_t *args = (struct brotli_deflate_t *)arg;
+
+    brotli::BrotliMemIn in(args->str, args->str_length);
+    args->buf.reserve(args->str_length * 2 + 1);
+    brotli::BrotliStringOut out(&args->buf, args->buf.capacity());
+
+    return (void *)brotli::BrotliCompress(*(args->params), &in, &out);
+}
+
 static VALUE
 brotli_deflate(int argc, VALUE *argv, VALUE self)
 {
@@ -134,15 +156,17 @@ brotli_deflate(int argc, VALUE *argv, VALUE self)
         brotli_deflate_parse_options(params, opts);
     }
 
-    brotli::BrotliMemIn in(RSTRING_PTR(str), RSTRING_LEN(str));
-    std::string buf;
-    buf.reserve(RSTRING_LEN(str) * 2 + 1);
-    brotli::BrotliStringOut out(&buf, buf.capacity());
-    if (!brotli::BrotliCompress(params, &in, &out)) {
+    struct brotli_deflate_t args = {
+        .str = RSTRING_PTR(str),
+        .str_length = RSTRING_LEN(str),
+        .params = &params
+    };
+    if (!rb_thread_call_without_gvl(brotli_deflate_no_gvl, (void *)&args, NULL, NULL)) {
         rb_raise(rb_eBrotli, "ERROR");
     }
 
-    return rb_str_new(buf.c_str(), buf.size());
+
+    return rb_str_new(args.buf.c_str(), args.buf.size());
 }
 
 extern "C" {

--- a/ext/brotli/brotli.cc
+++ b/ext/brotli/brotli.cc
@@ -126,8 +126,8 @@ struct brotli_deflate_args_t
 {
     char *str;
     size_t str_length;
-    std::string buf;
     brotli::BrotliParams *params;
+    std::string buf;
 
 } brotli_deflate_args_t;
 
@@ -157,9 +157,9 @@ brotli_deflate(int argc, VALUE *argv, VALUE self)
     }
 
     struct brotli_deflate_args_t args = {
-        .str = RSTRING_PTR(str),
-        .str_length = RSTRING_LEN(str),
-        .params = &params
+        RSTRING_PTR(str),
+        RSTRING_LEN(str),
+        &params
     };
     if (!rb_thread_call_without_gvl(brotli_deflate_no_gvl, (void *)&args, NULL, NULL)) {
         rb_raise(rb_eBrotli, "ERROR");


### PR DESCRIPTION
This will allow threads to run while we're compressing.
It's not easy to release the GVL while decompressing since we are streaming the output to a ruby string.
Is there any way around that?