### PR TITLE
mkmf globs files - globbing order is not guaranteed

### DIFF
--- a/ext/brotli/extconf.rb
+++ b/ext/brotli/extconf.rb
@@ -32,8 +32,8 @@ File.open('Makefile', 'r+') do |f|
   src = 'ORIG_SRCS = brotli.c buffer.c'
   obj = 'OBJS = brotli.o buffer.o'
   txt = f.read
-        .sub(/^#{src}$/, src + ' ' + srcs.join(' '))
-        .sub(/^#{obj}$/, obj + ' ' + objs.join(' '))
+        .sub(/^ORIG_SRCS = .*$/, src + ' ' + srcs.join(' '))
+        .sub(/^OBJS = .*$/, obj + ' ' + objs.join(' '))
   f.rewind
   f.write txt
 end


### PR DESCRIPTION
Depending on host system the order of buffer.c and brotli.c changes, so doing an exact match will have a chance of not working (depending on how the file system offers the files to glob).