### PR TITLE
README: add note about git submodule update --init

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ See spec/brotli_spec.rb
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Run `rake build` to build brotli extension for ruby. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies.
+
+`git submodule update --init` to ensure the Brotli dependencies are available.
+
+Run `rake build` to build brotli extension for ruby. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
This PR adds a useful hint to the user who wants to build the gem from source:

Source: [google/woff2 issue report about the same thing](https://github.com/google/woff2/issues/19)