### PR TITLE
setup script: include git submodule update --init

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ See spec/brotli_spec.rb
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies.
-
-`git submodule update --init` to ensure the Brotli dependencies are available.
+After checking out the repo, run `bin/setup` to install bundle and Brotli C library dependencies.
 
 Run `rake build` to build brotli extension for ruby. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 

--- a/bin/setup
+++ b/bin/setup
@@ -4,4 +4,5 @@ IFS=$'\n\t'
 
 bundle install
 
-# Do any other automated setup that you need to do here
+# Ensure Brotli library dependencies are available
+git submodule update --init


### PR DESCRIPTION
This PR improves the life of the developer coming to this project by adding the step "git submodule update --init" to the bash script to setup development environment.