### PR TITLE
Always use the object extension in rbconfig in `extconf.rb`.

### DIFF
--- a/ext/brotli/extconf.rb
+++ b/ext/brotli/extconf.rb
@@ -22,8 +22,9 @@ Dir[File.expand_path(File.join('{enc,dec,common,include}', '**', '*.c'), __DIR__
 end
 
 File.open('Makefile', 'r+') do |f|
+  obj_ext = RbConfig::CONFIG['OBJEXT']
   src = 'ORIG_SRCS = brotli.c buffer.c'
-  obj = 'OBJS = brotli.o buffer.o'
+  obj = "OBJS = brotli.#{obj_ext} buffer.#{obj_ext}"
   txt = f.read
         .sub(/^ORIG_SRCS = .*$/, src + ' ' + srcs.join(' '))
         .sub(/^OBJS = .*$/, obj + ' ' + objs.join(' '))


### PR DESCRIPTION
This is half of the fix for a problem with building Brotli on TruffleRuby (https://github.com/oracle/truffleruby/issues/1638). We currently compile C extensions to llvm bitcode, and store that in `.bc` files, so our make files don't contain correct rules for building `.o` files.

This patch changes `extconf.rb` to use the `'OBJEXT'` entry in rbconfig to avoid assuming the wrong extensions.

The other half of the fix is in TruffleRuby itself and I'm putting it through our CI at the moment.