### PR TITLE
Use max buffer size in brotli_deflate to avoid realloc during compression

### DIFF
--- a/ext/brotli/brotli.c
+++ b/ext/brotli/brotli.c
@@ -262,7 +262,8 @@ brotli_deflate(int argc, VALUE *argv, VALUE self)
     args.s = brotli_deflate_parse_options(
         BrotliEncoderCreateInstance(brotli_alloc, brotli_free, NULL),
         opts);
-    args.buffer = create_buffer(BUFSIZ);
+    size_t max_compressed_size = BrotliEncoderMaxCompressedSize(args.len);
+    args.buffer = create_buffer(max_compressed_size);
     args.finished = BROTLI_FALSE;
 
 #ifdef HAVE_RUBY_THREAD_H

--- a/ext/brotli/buffer.c
+++ b/ext/brotli/buffer.c
@@ -1,9 +1,10 @@
 #include "buffer.h"
+#include "ruby/ruby.h"
 #define INITIAL (1024)
 
 buffer_t*
 create_buffer(const size_t initial) {
-    buffer_t *buffer = malloc(sizeof(buffer_t));
+    buffer_t *buffer = ruby_xmalloc(sizeof(buffer_t));
     if (buffer == NULL) {
         return NULL;
     }
@@ -12,7 +13,7 @@ create_buffer(const size_t initial) {
     buffer->expand_count = 0;
     buffer->expand_ratio = 130;
     buffer->size = (size_t) (initial > 0 ? initial : INITIAL);
-    buffer->ptr = malloc(buffer->size);
+    buffer->ptr = ruby_xmalloc(buffer->size);
     if (buffer->ptr == NULL) {
         delete_buffer(buffer);
         return NULL;
@@ -24,17 +25,17 @@ create_buffer(const size_t initial) {
 void
 delete_buffer(buffer_t* buffer) {
     if (buffer->ptr != NULL) {
-        free(buffer->ptr);
+        ruby_xfree(buffer->ptr);
         buffer->ptr = NULL;
     }
-    free(buffer);
+    ruby_xfree(buffer);
 }
 
 static
 buffer_t*
 expand_buffer(buffer_t* const buffer, const size_t need) {
     size_t size = need * buffer->expand_ratio / 100;
-    buffer->ptr = realloc(buffer->ptr, size);
+    buffer->ptr = ruby_xrealloc(buffer->ptr, size);
     buffer->size = size;
     buffer->expand_count += 1;
     return buffer;


### PR DESCRIPTION
This PR does a couple of small things:

1. When deflating data with too small of a buffer size, it's possible to trigger a bunch of `realloc` calls. Better to allocate up front with `BrotliEncoderMaxCompressedSize`
2. Use `ruby_x*` suite of functions to better integrate with Ruby's GC